### PR TITLE
Fix Popover mispositioned and detached when triggering on hover if the trigger element is removed from the DOM

### DIFF
--- a/projects/material-extended/mde/src/lib/popover/popover-trigger.ts
+++ b/projects/material-extended/mde/src/lib/popover/popover-trigger.ts
@@ -255,6 +255,10 @@ export class MdePopoverTrigger implements AfterViewInit, OnDestroy { // tslint:d
 
     /** Removes the popover from the DOM. */
     destroyPopover(): void {
+        if (this._mouseoverTimer) {
+            clearTimeout(this._mouseoverTimer);
+            this._mouseoverTimer = null;
+        }        
         if (this._overlayRef) {
           this._overlayRef.dispose();
           this._overlayRef = null;

--- a/projects/material-extended/mde/src/lib/popover/popover-trigger.ts
+++ b/projects/material-extended/mde/src/lib/popover/popover-trigger.ts
@@ -258,7 +258,7 @@ export class MdePopoverTrigger implements AfterViewInit, OnDestroy { // tslint:d
         if (this._mouseoverTimer) {
             clearTimeout(this._mouseoverTimer);
             this._mouseoverTimer = null;
-        }        
+        }
         if (this._overlayRef) {
           this._overlayRef.dispose();
           this._overlayRef = null;


### PR DESCRIPTION
Removing the mouseoverTimer when the component is destroyed fixes the problem described in [Popover mispositioned and detached when triggering on hover if the trigger element is removed from the DOM](https://github.com/material-extended/mde/issues/34)