### PR TITLE
Cant destroy on ngAfterViewInit #58

### DIFF
--- a/projects/material-extended/mde/src/lib/popover/popover-trigger.ts
+++ b/projects/material-extended/mde/src/lib/popover/popover-trigger.ts
@@ -263,8 +263,8 @@ export class MdePopoverTrigger implements AfterViewInit, OnDestroy { // tslint:d
         if (this._overlayRef) {
           this._overlayRef.dispose();
           this._overlayRef = null;
-          this._cleanUpSubscriptions();
         }
+        this._cleanUpSubscriptions();
     }
 
     /** Focuses the popover trigger. */


### PR DESCRIPTION
#58 
_cleanUpSubscriptions method is not dependant on verlayRef existance and can be called independently