### PR TITLE
Add a simple reposition function.

### DIFF
--- a/projects/material-extended/mde/src/lib/popover/popover-trigger.ts
+++ b/projects/material-extended/mde/src/lib/popover/popover-trigger.ts
@@ -240,7 +240,7 @@ export class MdePopoverTrigger implements AfterViewInit, OnDestroy { // tslint:d
     openPopover(): void {
         if (!this._popoverOpen && !this._halt) {
             this._createOverlay().attach(this._portal);
-    
+
             this._subscribeToBackdrop();
             this._subscribeToDetachments();
 
@@ -255,6 +255,13 @@ export class MdePopoverTrigger implements AfterViewInit, OnDestroy { // tslint:d
           this._overlayRef.detach();
           this._resetPopover();
         }
+    }
+
+    repositionPopover(): void {
+      if (this._overlayRef != null) {
+        const config = this._getOverlayConfig();
+        this._overlayRef.updatePositionStrategy(config.positionStrategy);
+      }
     }
 
     /** Removes the popover from the DOM. */
@@ -345,7 +352,7 @@ export class MdePopoverTrigger implements AfterViewInit, OnDestroy { // tslint:d
     private _setPopoverOpened(): void {
       if (!this._popoverOpen) {
         this._popoverOpen = true;
-        
+
         this.popoverOpened.next();
         this.opened.emit()
       }
@@ -355,7 +362,7 @@ export class MdePopoverTrigger implements AfterViewInit, OnDestroy { // tslint:d
     private _setPopoverClosed(): void {
       if (this._popoverOpen) {
         this._popoverOpen = false;
-        
+
         this.popoverClosed.next();
         this.closed.emit();
       }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -21,6 +21,16 @@
   </li>
 </ul>
 
+<p>
+  Reposition
+</p>
+
+<button mat-raised-button color="primary" #repositionTrigger="mdePopoverTrigger" [mdePopoverTriggerFor]="popover5" (click)="onClick()">
+  Reposition
+</button>
+<button mat-raised-button color="accent"(click)="onReset()">
+  Reset
+</button>
 
 <mde-popover #popover1="mdePopover" [mdePopoverLeaveDelay]="1000">
   <mat-card class="example-card">
@@ -79,4 +89,12 @@
   </mat-card>
 </mde-popover>
 
-
+<mde-popover #popover5="mdePopover"
+  [mdePopoverOffsetX]="offsetX"
+  mdePopoverOffsetY="40"
+  mdePopoverPositionX="after"
+  mdePopoverPositionY="below">
+	<mat-card>
+		offsetX: {{ offsetX }}px
+	</mat-card>
+</mde-popover>

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
+import { MdePopoverTrigger } from '@material-extended/mde';
 
 @Component({
   selector: 'page-home',
@@ -7,10 +8,27 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HomeComponent implements OnInit {
+  @ViewChild('repositionTrigger') trigger: MdePopoverTrigger;
+
+  offsetX = 0;
 
   constructor() { }
 
   ngOnInit() {
+  }
+
+  onClick() {
+    this.offsetX += 100;
+    setTimeout(() => {
+      this.trigger.repositionPopover();
+    });
+  }
+
+  onReset() {
+    this.offsetX = 0;
+    setTimeout(() => {
+      this.trigger.repositionPopover();
+    });
   }
 
 }


### PR DESCRIPTION
For #302.
 
Added a function so that the tooltip can be repositioned manually when offsets change. However there seems to be some weird positioning behavior when used with `[mdePopoverOverlapTrigger]="false"`. The reposition causes the popover to be misaligned above the trigger, even when explicitly setting `mdePopoverPositionY="below"`.